### PR TITLE
Fix bug in make_ag() if statement

### DIFF
--- a/sage.py
+++ b/sage.py
@@ -2677,8 +2677,8 @@ def make_AG(condensed_v_data, condensed_data, state_groups, sev_sinks, datafile,
             nodes = {}
             vertices, edges = 0, 0
             for att,episodes in condensed_data.items(): # iterate over (a,v): [episode, episode, episode]
-                if int_victim not in att: # if it's not the right victim, then don't process further
-                    continue  
+                if int_victim != att.split(">")[1]: # if it's not the right victim, then don't process further
+                    continue
                 vname_time = []
                 for ep in episodes:
                     start_time = round(ep[0]/1.0)


### PR DESCRIPTION
**Bug:** 
The if statement on line 2860 compares victims using "in" leading to returning True for wrong (similar) victim IPs 

**Proposed fix:**
Extract the victim's IP from the attack string and compare them using equals.

An example of a false positive when running the sample alerts:
![image](https://github.com/tudelft-cda-lab/SAGE/assets/101674052/254b673d-431f-4dac-8752-68fe3c53b626)
These all return True, even though the victims are not part of the attack.

**Result of fix:**
Victim 10.0.99.225 for Network DoS (left before fix, right after fix)
![image](https://github.com/tudelft-cda-lab/SAGE/assets/101674052/09e11e88-5b24-4ad9-8343-a73c890d3f67)
Victim 10.0.99.22 for Network DoS (left before fix, right after fix)
![image](https://github.com/tudelft-cda-lab/SAGE/assets/101674052/29cc7c15-2099-4abb-8fba-abbefc996b2d)

As can be seen, the paths from the first victim are no longer part of the second victim's.

CPTC-2017 now results in 108 AGs instead of 167, and CPTC-2018 results in 75 instead of 76 AGs
