### PR TITLE
Change Unknown/unknown to behave the same on both linux and windows

### DIFF
--- a/sage.py
+++ b/sage.py
@@ -1340,7 +1340,7 @@ def load_IANA_mapping():
 
             for port in range(low_port, high_port + 1):
                 ports[port] = {
-                    "name": row[0] if row[0] else "Unknown",
+                    "name": row[0] if row[0] else "unknown",
                     "description": row[3] if row[3] else "---",
                 }
         else:


### PR DESCRIPTION
**Bug**

There were differences in the number of attack graphs generated between users running SAGE on Linux and Windows. We believe this was due to the "Unknown/unknown" protocol and how Linux and Windows handle case sensitivity of file names. 

**Proposed fix**

In case the IANA mapping doesn't have a port, instead of overriding it with "Unknown", override it with "unknown". This way there is no confusion with case sensitivity.

**Example of wrong behaviour**

For example, on a Linux machine, one would get 167 attack graphs for the 2017 dataset, while on a Windows machine, one would get 162.

**Example behaviour after fix**

After the fix, the results are consistent between Linux and Windows users, with both machines getting 162 attack graphs.


