### PR TITLE
Fix redundant duplicate attacks in make_AG method

### DIFF
--- a/sage.py
+++ b/sage.py
@@ -2704,7 +2704,7 @@ def make_AG(condensed_v_data, condensed_data, state_groups, sev_sinks, datafile,
                 sub_attempt = []
                 for (vname, start_time, end_time, signs, ts) in vname_time: # cut each attempt until the requested objective
                     sub_attempt.append((vname, start_time, end_time, signs, ts)) # add the vertex in path
-                    if attack in vname: # if it's the objective
+                    if attack.split("|")[:2] == vname.split("|")[:2]: # if it's the objective
                         if len(sub_attempt) <= 1: ## If only a single node, reject
                             sub_attempt = []
                             continue


### PR DESCRIPTION
## Description

The if statement on line 2707 compares current `attack` (objective) with `vname` (potential objective variant) using "in" operator. This results in returning True for wrong (similar) `attack`s that are substrings of `vname`.
An example of a false positive when running SAGE on CPTC-2017 dataset:

![pr2 1](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/8a05bdcc-b0db-47c2-b627-4154293fee1c)
![pr2 2](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/0037ba61-9a1c-486c-a175-2bf6333f2911)
![pr2 3](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/01debd72-afb6-4d85-8460-af4314c10d92)

Here, the condition `attack in vname` evaluates to True if `attack=DATA_EXFILTRATION|http` and `vname=DATA_EXFILTRATION|http-alt|46`, whereas it should not be the case.

## Proposed fix

Split both `attack` and `vname` on “|” and compare the first two parts, which are in either case the `mcat` and `mserv`, using equals.

![pr2 4](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/94c401f6-94c1-4ac6-b7dc-de3709e9e82c)

## Result of fix

Three redundant attack graph have disappeared in CPTC-2017 (CPTC-2018 not affected):

![pr2 5](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/b7869006-c9fe-4d7b-b30d-dcf2c030a7c7)

**Victim 10.0.99.44 for `Data Delivery | http` (before the fix)** - incorrect

![pr2 6](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/ec87a249-9892-489c-9c32-b7c018fa7d54)

**Victim 10.0.99.44 for `Data Delivery | http-alt` (before the fix)** - correct
![pr2 7](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/6a6f4e34-3026-4efa-9c63-a875f908d418)

**Victim 10.0.99.44 for `Data Delivery | http-alt` (after the fix)** - correct

![pr2 8](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/dc5f4863-bcab-43c7-bf58-f7a2059124d6)

Four attack graphs have been affected in CPTC-2017 (CPTC-2018 not affected)
![pr2 9](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/a6d7a990-916f-472b-9855-9abf8608a23e)

**Victim 10.0.0.27 for `Data Exfiltration | http` (before the fix)** - a wrong path leading to the objective variant `Data Exfiltration | http-alt | ID: 48`, while the objective is `Data Exfiltration | http`

![pr2 10](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/5bf38b63-d729-426e-a2c6-1e4285d32863)

**Victim 10.0.0.27 for `Data Exfiltration | http` (after the fix)**

![pr2 11](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/d43da138-6110-4983-ace9-4fe2b1bf83b5)

**Victim 10.0.254.32 for `Data Exfiltration | http` (before the fix)** - a wrong path leading to the objective variant `Data Exfiltration | http-alt | ID: 48`, while the objective is `Data Exfiltration | http`

![pr2 12](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/205c22c8-e00b-4aaa-a4ff-2c9c76ababf7)

**Victim 10.0.254.32 for `Data Exfiltration | http` (after the fix)**

![pr2 13](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/cb714dab-c9c1-4818-af0b-3cfb71d27df5)
