### PR TITLE
Add spdfa-config.ini with printblue=1

### DIFF
--- a/spdfa-config.ini
+++ b/spdfa-config.ini
@@ -1,0 +1,20 @@
+[default]
+heuristic-name = alergia
+data-name = alergia_data
+symbol_count = 5
+satdfabound = 2000
+sinkson = 1
+state_count = 5
+sinkcount = 5
+extrapar = 0.05
+largestblue = 1
+finalred = 0
+extend = 0
+lowerbound = 3
+finalprob = 1
+markovian = 1
+mcollector = -1
+mergelocal = -1
+printwhite = 0
+printblue = 1
+outputsinks = 1


### PR DESCRIPTION
As was mentioned in PR https://github.com/tudelft-cda-lab/SAGE/pull/14, the issue with transitions between non-sink states and sink states can be solved by setting `printblue=1`. This PR addresses this issue.

Furthermore, this PR adds `spdfa-config.ini` config file to the main SAGE branch. `docker` branch will use this file when building the image (addressed in PR https://github.com/tudelft-cda-lab/SAGE/pull/16).