### PR TITLE
Update Dockerfile to copy all SAGE files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN cd /root \
 
 RUN cd /root \
     && git clone https://github.com/tudelft-cda-lab/SAGE.git \
-    && cd SAGE && cp -R sage.py signatures/ ../ && cp spdfa-config.ini ../FlexFringe/ini/
+    && cd SAGE && cp -R *.py signatures/ ../ && cp spdfa-config.ini ../FlexFringe/ini/
 
 
 


### PR DESCRIPTION
Updates the Dockerfile to copy all SAGE files, after SAGE has been split into multiple files (see PR #33).

NB! This PR has to be merged after PR #33 