### PR TITLE
Add argumentparser to SAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Repository to accompany our publications
 ## Requires 
 - Flexfringe (https://github.com/tudelft-cda-lab/FlexFringe)
 - Python packages
-  - Graphviz
-  - Seaborn
-  - Requests
+  - `graphviz`
+  - `requests`
+  - `numpy`
+  - `matplotlib`
   - [Optional] Fastai (1.0.58)
   - [Optional] Spacy 2.3.5
 
@@ -18,25 +19,43 @@ Repository to accompany our publications
 
 
 ## Usage
-`python sage.py {path/to/json/files} {experiment-name} {alert-filtering-window} {alert-aggr-window} {(start_hour,end_hour)}`
+`python sage.py path_to_json_files experiment_name [-h] [-t T] [-w W] [--timerange TIMERANGE TIMERANGE] [--dataset {cptc,other}] [--keep-files]`
 
-- `{path/to/json/files}`: folder containing intrusion alerts in json format. `sample-input.json` provides an example of accepted file format. 
-> Ideal setting: One json file for each attacker/team. Filename considered as attacker/team label. 
-- `{experiment_name}`: custom name for all artefacts
-> Figures, trace files, model files, attack graphs are saved with this prefix for easy identification. 
-- `{alert_filtering_window}`: time window in which duplicate alerts are discarded (default: 1.0 sec)
-- `{alert_aggr_window}`: aggregate alerts occuring in this window as one episode (default: 150 sec)
-- [Optional] `{(start_hour,end_hour)}`: Time range (in hours). A floating-point tuple limiting the alerts that are parsed and involved in the final attack graphs. 
+Required positional arguments:
+
+* `path_to_json_files`: Directory containing intrusion alerts in json format. `sample-input.json` provides an example of the accepted file format.
+> Ideal setting: One json file for each attacker/team. Filename considered as attacker/team label.
+* `experiment_name`: Custom name for all artefacts.
+> Figures, trace files, model files, attack graphs are saved with this prefix for easy identification.
+
+Options:
+
+* `-h`, `--help`: Show the help message and exit.
+* `-t`: Time window in which duplicate alerts are discarded (default: 1.0 sec).
+* `-w`: Aggregate alerts occuring in this window as one episode (default: 150 sec).
+* `--timerange`: A floating-point tuple limiting the alerts that are parsed and involved in the final attack graphs (default: (0, 100)).
 > If not provided, the default values of (0,100) are used, meaning alerts from 0-th to 100-th hour (relative to the start of the alert capture) are parsed.
+* `--dataset`: The name of the dataset with the alerts (default: other, available options: cptc, other).
+> Since the IP addresses of the attackers are known for the CPTC dataset, irrelevant alerts are filtered out.
+* `--keep-files`: Do not delete the dot files after the program ends.
+> By default, the generated dot files with the attack graphs are deleted. They might, however, be useful for analytics or testing.
+
+Examples:
+
+* Run SAGE with the default parameters on the CPTC-2017 dataset: `python sage.py alerts/cptc-2017/ exp-2017 --dataset cptc`
+* Run SAGE with the time window of 2.0 seconds and the alert aggregation window of 200 seconds on the CPTC-2018 dataset: `python sage.py alerts/cptc-2018/ exp-2018 -t 2.0 -w 200 --dataset cptc`
+* Run SAGE on the CCDC dataset and do not delete the dot files (you can omit `--option other`): `python sage.py alerts/ccdc/ exp-ccdc --dataset other --keep-files`
+
+Tip: in case you often use the same non-default values, you can create an alias (e.g `alias sage="python sage.py -t 1.5 --dataset cptc --keep-files"` and then run `sage alerts/cptc-2017/ exp-2017`)
 
 ## First time use
 
 - In `sage.py`, set paths to `flexfringe/` executable, and `path_to_ini` variable.
 - A sample alert file is provided with the name `sample-input.json` (T5 alerts from CPTC-2018) to test SAGE. Use the following command: 
 
-`python sage.py alerts/ firstExp 1.0 150`
+`python sage.py alerts/ firstExp`
 
-where `alerts/` contains `sample-input.json`.
+where `alerts/` contains `sample-input.json`. For other options, see Usage section above.
 
 **If you use SAGE in a scientific work, consider citing the following papers:**
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Examples:
 
 * Run SAGE with the default parameters on the CPTC-2017 dataset: `python sage.py alerts/cptc-2017/ exp-2017 --dataset cptc`
 * Run SAGE with the time window of 2.0 seconds and the alert aggregation window of 200 seconds on the CPTC-2018 dataset: `python sage.py alerts/cptc-2018/ exp-2018 -t 2.0 -w 200 --dataset cptc`
-* Run SAGE on the CCDC dataset and do not delete the dot files (you can omit `--option other`): `python sage.py alerts/ccdc/ exp-ccdc --dataset other --keep-files`
+* Run SAGE on the CCDC dataset and do not delete the dot files (you can omit `--dataset other`): `python sage.py alerts/ccdc/ exp-ccdc --dataset other --keep-files`
 
 Tip: in case you often use the same non-default values, you can create an alias (e.g `alias sage="python sage.py -t 1.5 --dataset cptc --keep-files"` and then run `sage alerts/cptc-2017/ exp-2017`)
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,12 @@ Repository to accompany our publications
   - `requests`
   - `numpy`
   - `matplotlib`
-  - [Optional] Fastai (1.0.58)
-  - [Optional] Spacy 2.3.5
 
 **Or you can switch to the `docker` branch for a docker container.**
 
 
 ## Usage
-`python sage.py path_to_json_files experiment_name [-h] [-t T] [-w W] [--timerange TIMERANGE TIMERANGE] [--dataset {cptc,other}] [--keep-files]`
+`python sage.py path_to_json_files experiment_name [-h] [-t T] [-w W] [--timerange STARTRANGE ENDRANGE] [--dataset {cptc,other}] [--keep-files]`
 
 Required positional arguments:
 

--- a/sage.py
+++ b/sage.py
@@ -1,3 +1,4 @@
+import argparse
 import csv
 import datetime
 import glob
@@ -1206,24 +1207,24 @@ def make_attack_graphs(victim_episodes, state_sequences, sev_sinks, datafile, di
 
 
 # ----- MAIN ------
+# Usage: sage.py {path/to/json/files} {experiment_name} {alert_filtering_window (def=1.0)} {alert_aggr_window (def=150)} {(start_hour,end_hour)[Optional]}
+parser = argparse.ArgumentParser(description='SAGE: Intrusion Alert-Driven Attack Graph Extractor.')
+parser.add_argument('path_to_json_files', type=str, help='Directory containing intrusion alerts in json format. sample-input.json provides an example of the accepted file format')
+parser.add_argument('experiment_name', type=str, help='Custom name for all artefacts')
+parser.add_argument('-t', type=float, required=False, default=1.0, help='Time window in which duplicate alerts are discarded (default: 1.0 sec)')
+parser.add_argument('-w', type=int, required=False, default=150, help='Aggregate alerts occuring in this window as one episode (default: 150 sec)')
+parser.add_argument('--filter', type=int, nargs=2, required=False, default=[0, 100], help='Filtering alerts. Only parsing from and to the specified hours, relative to the start of the alert capture (default: (0, 100))')
+parser.add_argument('--dataset', required=False, type=str, choices=['cptc', 'other'], default='other', help='The name of the dataset with the alerts (default: other)')
+parser.add_argument('--no-clean', action='store_false', help='Do not delete the dot files after the program ends')
+args = parser.parse_args()
 
-if len(sys.argv) < 5:
-    print('Usage: sage.py {path/to/json/files} {experiment_name} {alert_filtering_window (def=1.0)} {alert_aggr_window (def=150)} {(start_hour,end_hour)[Optional]}')
-    sys.exit()
-
-path_to_json_files = sys.argv[1]
-experiment_name = sys.argv[2]
-alert_filtering_window = float(sys.argv[3])
-alert_aggr_window = int(sys.argv[4])
-start_hour, end_hour = 0, 100
-if len(sys.argv) > 5:
-    try:
-        start_hour = float(sys.argv[5])
-        end_hour = float(sys.argv[6])
-        print('Filtering alerts. Only parsing from %d-th to %d-th hour (relative to the start of the alert capture)' % (start_hour, end_hour))
-    except (ValueError, TypeError):
-        print('Error parsing hour filter range')
-        sys.exit()
+path_to_json_files = args.path_to_json_files
+experiment_name = args.experiment_name
+alert_filtering_window = args.t
+alert_aggr_window = args.w
+start_hour, end_hour = args.filter
+dataset_name = args.dataset
+DOCKER = args.no_clean  # Alternatively, this can be renamed to CLEAN (instead of DOCKER) to make it more clear
 
 # We cheat a bit: In case user filters to only see alerts from (s,e) range,
 #   we record the first alert just to get the real time-elapsed since first alert

--- a/sage.py
+++ b/sage.py
@@ -20,8 +20,7 @@ from signatures.alert_signatures import usual_mapping, unknown_mapping, ccdc_com
 
 IANA_CSV_FILE = "https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.csv"
 IANA_NUM_RETRIES = 5
-SAVE = True
-DOCKER = True
+SAVE_AG = True
 
 
 def _get_attack_stage_mapping(signature):
@@ -155,7 +154,7 @@ def _remove_duplicates(unfiltered_alerts, plot=False, gap=1.0):
 
 
 # Step 1: Read the input alerts
-def load_data(path_to_alerts, filtering_window, start_hour, end_hour):
+def load_data(path_to_alerts, filtering_window, start, end):
     _team_alerts = []
     _team_labels = []
     _team_start_times = []  # Record the first alert just to get the real elapsed time (if the user filters (s,e) range)
@@ -174,8 +173,8 @@ def load_data(path_to_alerts, filtering_window, start_hour, end_hour):
 
         # EXP: Limit alerts by timing is better than limiting volume because each team is on a different scale.
         # 50% alerts for one team end at a diff time than for others
-        end_time_limit = 3600 * end_hour       # Which hour to end at?
-        start_time_limit = 3600 * start_hour   # Which hour to start from?
+        end_time_limit = 3600 * end       # Which hour to end at?
+        start_time_limit = 3600 * start   # Which hour to start from?
 
         first_ts = parsed_alerts[0][8]
         _team_start_times.append(first_ts)
@@ -218,25 +217,25 @@ def group_alerts_per_team(alerts, port_mapping):
         _team_data[tid] = host_alerts.items()
     return _team_data
 
+
 # ----- MAIN ------
-# Usage: sage.py {path/to/json/files} {experiment_name} {alert_filtering_window (def=1.0)} {alert_aggr_window (def=150)} {(start_hour,end_hour)[Optional]}
 parser = argparse.ArgumentParser(description='SAGE: Intrusion Alert-Driven Attack Graph Extractor.')
 parser.add_argument('path_to_json_files', type=str, help='Directory containing intrusion alerts in json format. sample-input.json provides an example of the accepted file format')
 parser.add_argument('experiment_name', type=str, help='Custom name for all artefacts')
 parser.add_argument('-t', type=float, required=False, default=1.0, help='Time window in which duplicate alerts are discarded (default: 1.0 sec)')
 parser.add_argument('-w', type=int, required=False, default=150, help='Aggregate alerts occuring in this window as one episode (default: 150 sec)')
-parser.add_argument('--filter', type=int, nargs=2, required=False, default=[0, 100], help='Filtering alerts. Only parsing from and to the specified hours, relative to the start of the alert capture (default: (0, 100))')
+parser.add_argument('--timerange', type=int, nargs=2, required=False, default=[0, 100], help='Filtering alerts. Only parsing from and to the specified hours, relative to the start of the alert capture (default: (0, 100))')
 parser.add_argument('--dataset', required=False, type=str, choices=['cptc', 'other'], default='other', help='The name of the dataset with the alerts (default: other)')
-parser.add_argument('--no-clean', action='store_false', help='Do not delete the dot files after the program ends')
+parser.add_argument('--keep-files', action='store_true', help='Do not delete the dot files after the program ends')
 args = parser.parse_args()
 
 path_to_json_files = args.path_to_json_files
 experiment_name = args.experiment_name
 alert_filtering_window = args.t
 alert_aggr_window = args.w
-start_hour, end_hour = args.filter
+start_hour, end_hour = args.timerange
 dataset_name = args.dataset
-DOCKER = args.no_clean  # Alternatively, this can be renamed to CLEAN (instead of DOCKER) to make it more clear
+delete_files = not args.keep_files
 
 path_to_ini = "FlexFringe/ini/spdfa-config.ini"
 
@@ -307,9 +306,9 @@ print('------ Grouping episodes per (team, victim) ------')
 episodes_per_victim, _ = group_episodes_per_av(state_sequences)
 
 print('------ Making alert-driven AGs ------')
-make_attack_graphs(episodes_per_victim, state_sequences, severe_sinks, path_to_traces, ag_directory, SAVE)
+make_attack_graphs(episodes_per_victim, state_sequences, severe_sinks, path_to_traces, ag_directory, SAVE_AG)
 
-if DOCKER:
+if delete_files:
     print('Deleting extra files')
     os.system("rm " + path_to_traces + ".ff.final.dot")
     os.system("rm " + path_to_traces + ".ff.final.json")

--- a/sage.py
+++ b/sage.py
@@ -224,7 +224,7 @@ parser.add_argument('path_to_json_files', type=str, help='Directory containing i
 parser.add_argument('experiment_name', type=str, help='Custom name for all artefacts')
 parser.add_argument('-t', type=float, required=False, default=1.0, help='Time window in which duplicate alerts are discarded (default: 1.0 sec)')
 parser.add_argument('-w', type=int, required=False, default=150, help='Aggregate alerts occuring in this window as one episode (default: 150 sec)')
-parser.add_argument('--timerange', type=int, nargs=2, required=False, default=[0, 100], help='Filtering alerts. Only parsing from and to the specified hours, relative to the start of the alert capture (default: (0, 100))')
+parser.add_argument('--timerange', type=int, nargs=2, required=False, default=[0, 100], metavar=('STARTRANGE', 'ENDRANGE'), help='Filtering alerts. Only parsing from and to the specified hours, relative to the start of the alert capture (default: (0, 100))')
 parser.add_argument('--dataset', required=False, type=str, choices=['cptc', 'other'], default='other', help='The name of the dataset with the alerts (default: other)')
 parser.add_argument('--keep-files', action='store_true', help='Do not delete the dot files after the program ends')
 args = parser.parse_args()


### PR DESCRIPTION
Applies the changes proposed in issue #25. Specifically, this PR:

1. Replaces the manual parsing with `ArgumentParser` (similar to [SECLEDS](https://github.com/tudelft-cda-lab/SECLEDS))
2. Adds one more option: `--dataset_name` (options = {"cptc", "other"}, default value = "other")
3. Adds another optional parameter to not remove the dot files (`--keep-files`)

Furthermore, a more extensive help page is now shown:
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/4f40e72e-6732-4b13-ae09-dff5763ff85a)

Closes issue #25.

NB! This PR has to be merged after the PR #33.