### PR TITLE
Move 10.0.254 checks and add checks for CPTC dataset

### DIFF
--- a/model_learning.py
+++ b/model_learning.py
@@ -177,11 +177,6 @@ def make_state_sequences(episode_subsequences, state_traces):
             continue
         counter += 1
 
-        if '10.0.254' not in attack:  # TODO: move all these checks to the `_group_alerts_per_team` function
-            continue
-        if '147.75' in attack or '69.172' in attack:
-            continue
-
         trace = [int(state) for state in state_traces[counter]]
         max_services = [_most_frequent(epi[6]) for epi in episode_subsequence]
 
@@ -192,25 +187,12 @@ def make_state_sequences(episode_subsequences, state_traces):
                              for i, epi in enumerate(episode_subsequence)]
 
         parts = attack.split('->')
-        team, attacker = parts[0].split('-')
-        victim, attack_num = parts[1].split('-')
-        attacker_victim = team + '-' + attacker + '->' + victim
-        attacker_victim_inv = team + '-' + victim + '->' + attacker
-        inv = False
-        if '10.0.254' in victim:
-            inv = True
+        attacker_victim = parts[0] + '->' + parts[1].split('-')[0]  # Remove the subsequence number (if present)
 
-        if attacker_victim not in state_sequences.keys() and attacker_victim_inv not in state_sequences.keys():
-            if inv:
-                state_sequences[attacker_victim_inv] = []
-            else:
-                state_sequences[attacker_victim] = []
-        if inv:
-            state_sequences[attacker_victim_inv].extend(state_subsequence)
-            state_sequences[attacker_victim_inv].sort(key=lambda epi: epi[0])  # Sort in place based on starting times
-        else:
-            state_sequences[attacker_victim].extend(state_subsequence)
-            state_sequences[attacker_victim].sort(key=lambda epi: epi[0])  # Sort in place based on starting times
+        if attacker_victim not in state_sequences.keys():
+            state_sequences[attacker_victim] = []
+        state_sequences[attacker_victim].extend(state_subsequence)
+        state_sequences[attacker_victim].sort(key=lambda epi: epi[0])  # Sort in place based on starting times
 
     return state_sequences
 

--- a/sage.py
+++ b/sage.py
@@ -203,14 +203,13 @@ def group_alerts_per_team(alerts, port_mapping):
             else:
                 dst_port = port_mapping[dst_port]['name']
 
-            # For CPTC dataset, attacker IPs (src_ip) start with '10.0.254', but this prefix might be in dst_ip
+            # For the CPTC dataset, attacker IPs (src_ip) start with '10.0.254', but this prefix might also be in dst_ip
             # TODO: for the future, we might want to address internal paths
             if dataset_name == 'cptc' and not src_ip.startswith('10.0.254') and not dst_ip.startswith('10.0.254'):
                 continue
+            # Swap src_ip and dst_ip, so that the prefix '10.0.254' is in src_ip
             if dataset_name == 'cptc' and dst_ip.startswith('10.0.254'):
-                temp = dst_ip
-                dst_ip = src_ip
-                src_ip = temp
+                src_ip, dst_ip = dst_ip, src_ip
 
             if (src_ip, dst_ip) not in host_alerts.keys() and (dst_ip, src_ip) not in host_alerts.keys():
                 host_alerts[(src_ip, dst_ip)] = []

--- a/sage.py
+++ b/sage.py
@@ -125,7 +125,7 @@ def _parse(unparsed_data, filter_alerts=False):
         dst_port = None if 'dest_port' not in raw.keys() else raw['dest_port']
 
         # Filter out mistaken alerts / uninteresting alerts
-        if dataset_name == 'cptc' and (src_ip == CPTC_BAD_IP or dst_ip == CPTC_BAD_IP or cat == 'Not Suspicious Traffic'):
+        if (dataset_name == 'cptc' and CPTC_BAD_IP in (src_ip, dst_ip)) or cat == 'Not Suspicious Traffic':
             continue
 
         mcat = _get_attack_stage_mapping(sig)


### PR DESCRIPTION
Closes issue #24.

Since the filtering based on the prefix `10.0.254` now happens before FlexFringe, the files with the episode traces are now different and, as a result, the IDs of the attack graphs are also different.

Nevertheless, if we compare the AGs without IDs, then they are the same (as can be seen in the output of my "custom" tests):
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/e40db369-0a6f-408f-91fd-53be184a756b)

When it comes to the input traces, for CPTC-2017 they are the same if we sort them, however for CPTC-2018, there are slight differences even when sorted, which, however, do not affect the AGs:
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/a9f684fe-d697-4286-858f-f3b0efe1598e)

UPDATE: after some investigation, it turns out that this happens because the check for `10.0.254` has been moved to be before FlexFringe
