### PR TITLE
Structure discarding short episode subsequences

### DIFF
--- a/episode_sequence_generation.py
+++ b/episode_sequence_generation.py
@@ -238,6 +238,9 @@ def break_into_subbehaviors(host_data, full_seq=False):
             if pieces < 1:  # TODO: double-check what is happening here
                 subsequences[attacker_victim + '-0'] = episodes
                 continue
+            if len(episodes) == 1:
+                subsequences[attacker_victim + '-0'] = episodes
+                continue
 
             # This part of the code only needs to cut the sequences at appropriate places -- no discarding is needed.
             # The discarding already happens later in make_attack_graphs.
@@ -255,14 +258,9 @@ def break_into_subbehaviors(host_data, full_seq=False):
                 end = cuts[j]
                 rest = (end + 1, len(episodes) - 1)
                 subsequence = episodes[start:end+1]
-                if len(subsequence) < 2:
-                    continue
                 subsequences[attacker_victim + '-' + str(count)] = subsequence
                 count += 1
             subsequence = episodes[rest[0]:rest[1]+1]
-            if len(subsequence) < 2:
-                # print('discarding symbol ', [x[2] for x in al]) # TODO This one is not cool1
-                continue
             subsequences[attacker_victim + '-' + str(count)] = subsequence
 
     print('\n# sub-sequences:', len(subsequences))

--- a/episode_sequence_generation.py
+++ b/episode_sequence_generation.py
@@ -198,8 +198,6 @@ def host_episode_sequences(team_episodes):
     for tid, team in enumerate(team_episodes):
         print(tid, sep=' ', end=' ', flush=True)
         for (attacker, victim), episodes in team.items():
-            if len(episodes) < 2:
-                continue
             # if ('10.0.0' in attacker or '10.0.1' in attacker):
             #        continue
 

--- a/episode_sequence_generation.py
+++ b/episode_sequence_generation.py
@@ -220,7 +220,6 @@ def host_episode_sequences(team_episodes):
 # Each episode subsequence represents an attack attempt.
 def break_into_subbehaviors(host_data, full_seq=False):
     subsequences = dict()
-    cut_length = 4
 
     print('----- Sub-sequences -----')
     for i, (attacker, victim_episodes) in enumerate(host_data.items()):
@@ -231,12 +230,8 @@ def break_into_subbehaviors(host_data, full_seq=False):
 
             victim = episodes[0][-1]
             attacker_victim = attacker + '->' + victim
-            pieces = math.floor(len(episodes) / cut_length)
             if full_seq:
                 subsequences[attacker_victim] = episodes
-                continue
-            if pieces < 1:  # TODO: double-check what is happening here
-                subsequences[attacker_victim + '-0'] = episodes
                 continue
             if len(episodes) == 1:
                 subsequences[attacker_victim + '-0'] = episodes


### PR DESCRIPTION
Closes #29 and #28

After the first commit, all attack graphs and episode traces are the same (I have intentionally split the changes into commits):
![subsequences](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/fd427b3c-bd65-417d-98b0-cb4e4d11a0c7)

![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/32d24b18-e463-45bc-aee1-48e73faf0d25)

After the second commit, there are changes in the attack graphs. In all datasets, there are fewer AGs.
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/8feaf0c9-a818-4fc6-a95c-74aa0825c6e7)
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/00251b62-4fab-4fc0-96d7-fcafb275d617)

For example, the following graphs have disappeared from CPTC-2017:
![orig-2017 txt-attack-graph-for-victim-10 0 0 224-NETWORKDOSmswbtserver](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/53b4a412-3f4b-4359-84af-dc7e5cba0060)
![orig-2017 txt-attack-graph-for-victim-10 0 99 21-DATADELIVERYunknown](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/5665fd7c-ac41-4ac6-8752-aaa4aa67f5b1)

and the following graph has disappeared from CPTC-2018 dataset:
![orig-2018 txt-attack-graph-for-victim-10 0 0 22-NETWORKDOShttp](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/8119a202-e0cf-4619-8698-f219286da341)

For CCDC, there are 16 AGs that have disappeared, but they are all of length two-three, for example:
![orig-ccdc txt-attack-graph-for-victim-10 47 4 150-DATAEXFILTRATIONhttps](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/d2f7c9f5-db39-464b-b5fa-655c6b63d140)
![orig-ccdc txt-attack-graph-for-victim-10 47 42 26-DATAEXFILTRATIONsmtp](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/4a5a9292-ce01-4dd6-bb46-4b270b49c78b)
![orig-ccdc txt-attack-graph-for-victim-10 47 46 213-NETWORKDOSntp](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/1ff5ee85-d8b8-43a5-add9-a853efcb646c)

The reason is that episode sequences of length <= 3 were added as they are, but now that `pieces` variable has been removed, they are used in the cutting process, where they can be split into smaller subsequences and discarded (as they are shorter than three). As a result, AGs are affected (with IDs most of them, without checking IDs only a few, see below):
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/5ef10524-e4a9-4e5d-ba7f-8af03f3d5ec5)
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/9786eea2-c7a6-49ac-a656-bb0cfd98eeeb)

The last commit changes the IDs and traces (relative to the old version), but not the attack graphs (if we remove the IDs):
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/f83ea343-b7ec-4dd6-b7b2-540dfbcfa631)

![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/ac214443-916d-46c0-a9b0-1c8d26a1b4e3)
