### PR TITLE
Add a tie-breaker for the most targeted service

### DIFF
--- a/model_learning.py
+++ b/model_learning.py
@@ -9,12 +9,17 @@ from signatures.mappings import small_mapping, rev_smallmapping
 def _most_frequent(serv):
     max_frequency = 0
     most_frequent_service = None
+    count_unknown = 0
     for s in serv:
         frequency = serv.count(s)
+        # Count the frequency of 'unknown' to break a tie against it
+        if s == 'unknown':
+            count_unknown = frequency
+            continue
         if frequency > max_frequency:
             most_frequent_service = s
             max_frequency = frequency
-    return most_frequent_service
+    return most_frequent_service if max_frequency >= count_unknown else 'unknown'
 
 
 # Step 4.2: Generate traces for FlexFringe (27 Aug 2020)


### PR DESCRIPTION
Closes #37.

When the frequency of "unknown" service is equal to the frequency of the most targeted service, then the concrete service is explicitly chosen as the most targeted service.

Most of the AGs have been affected when comparing with IDs. When comparing without IDs:
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/8b33cf34-fe40-4b92-abcd-f29e772bc321)
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/c6c96614-f4cc-4825-b09c-784ac4774c8c)


An example of a change in the tie-breaker (a small fragment from the CPTC-2017 dataset):
![mserv](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/15ba76e8-c24a-493c-8ab8-644ea34b9f04)
