### PR TITLE
Fix missing alert windows at the end

### DIFF
--- a/episode_sequence_generation.py
+++ b/episode_sequence_generation.py
@@ -18,7 +18,6 @@ def _get_ups_and_downs(frequencies, slopes):
     elif slopes[-1] == 0 and frequencies[-1] != 0:  # Special case where last slope is 0, but it is not the global min
         negative.append((len(slopes), slopes[-1]))
 
-
     common = set(negative).intersection(positive)
     negative = [item for item in negative if item not in common]
     positive = [item for item in positive if item not in common]

--- a/episode_sequence_generation.py
+++ b/episode_sequence_generation.py
@@ -15,6 +15,9 @@ def _get_ups_and_downs(frequencies, slopes):
         negative.append((len(slopes), slopes[-1]))
     elif slopes[-1] > 0:  # Special case for last ramp up without any ramp down
         negative.append((len(slopes), slopes[-1]))
+    elif slopes[-1] == 0 and frequencies[-1] != 0:  # Special case where last slope is 0, but it is not the global min
+        negative.append((len(slopes), slopes[-1]))
+
 
     common = set(negative).intersection(positive)
     negative = [item for item in negative if item not in common]


### PR DESCRIPTION
## Description

The function `_get_ups_and_downs` was discarding alert windows at the end of a hyperalert sequence in some cases.

The code checks whether the last slope is negative and whether the last slope is positive. However, there is also a(n) (edge) case when the last slope is 0, but it is not a global minimum, which is beautifully captured by the following two test cases (where `expected` is the output of the code):

```python
# Test case 2.5: start not detected (unfinished)
y = [39, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 28, 0, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 0, 0, 1, 1, 2, 1, 2, 2, 1, 1, 1, 2, 0, 1, 2, 0, 2, 1, 1, 1, 2, 1, 1, 0, 1, 1, 1, 1]
# slopes = [-330.0, -60.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 120.0, 160.0, -280.0, 20.0, 20.0, -40.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 40.0, 0.0, -40.0, 0.0, 10.0, 0.0, 10.0, -10.0, 10.0, 0.0, -10.0, 0.0, 0.0, 10.0, -20.0, 10.0, 10.0, -20.0, 20.0, -10.0, 0.0, 0.0, 10.0, -10.0, 0.0, -10.0, 10.0, 0.0, 0.0, 0.0]
expected = [(0, 2), (40, 46), (74, 77), (78, 100)]  # Why does it end with index 100 (i.e. the last 0)? The last four 1's are discarded?
run_episode_test(y, expected, "Test case 2.5: start not detected (unfinished)")

# Test case 3: last peak not detected (unfinished)
y = [36, 0, 0, 0, 2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 17, 0, 0, 0, 0, 0, 0, 33, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 6, 5, 6, 1, 2, 2]
# slopes = [-360.0, 0.0, 0.0, 20.0, 20.0, -40.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 120.0, 50.0, -170.0, 0.0, 0.0, 0.0, 0.0, 0.0, 330.0, -330.0, 10.0, -10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, -10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, 50.0, -10.0, 10.0, -50.0, 10.0, 0.0]
expected = [(0, 1), (3, 6), (40, 43), (48, 52), (58, 60), (72, 77)]  # Why does it end with index 77 (i.e. the last 1)? The last two 2's are discarded?
run_episode_test(y, expected, "Test case 3: last peak not detected (unfinished)")
```

![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/301ef8dc-6a01-4330-b61d-d9c52072e24d)

## Proposed fix

Add another if-check for the case when the last slope is 0, but it is not a global minimum:
![image](https://github.com/tudelft-cda-lab/SAGE/assets/45541174/412a69a3-fb06-487c-8337-374afe231b31)
